### PR TITLE
DataGenerator: Change to keras.Sequence & fix repitition issue

### DIFF
--- a/aucmedi/data_processing/data_generator.py
+++ b/aucmedi/data_processing/data_generator.py
@@ -20,7 +20,7 @@
 #                   Library imports                   #
 #-----------------------------------------------------#
 # External libraries
-from tensorflow.keras.preprocessing.image import Iterator
+from tensorflow.keras.utils import Sequence
 import numpy as np
 from multiprocessing.pool import ThreadPool
 from itertools import repeat
@@ -34,7 +34,7 @@ from aucmedi.data_processing.subfunctions import Standardize, Resize
 #-----------------------------------------------------#
 #                 Keras Data Generator                #
 #-----------------------------------------------------#
-class DataGenerator(Iterator):
+class DataGenerator(Sequence):
     """ Infinite Data Generator which automatically creates batches from a list of samples.
 
     The created batches are model ready. This generator can be supplied directly
@@ -188,6 +188,7 @@ class DataGenerator(Iterator):
             **kwargs (dict):                    Additional parameters for the sample loader.
         """
         # Cache class variables
+        self.samples = samples
         self.labels = labels
         self.metadata = metadata
         self.sample_weights = sample_weights
@@ -195,14 +196,22 @@ class DataGenerator(Iterator):
         self.workers = workers
         self.sample_loader = loader
         self.kwargs = kwargs
-        self.samples = samples
         self.path_imagedir = path_imagedir
         self.image_format = image_format
         self.grayscale = grayscale
         self.subfunctions = subfunctions
+        self.batch_size = batch_size
         self.data_aug = data_aug
         self.standardize_mode = standardize_mode
         self.resize = resize
+        self.shuffle = shuffle
+        self.seed = seed
+        # Cache keras.Sequence class variables
+        self.n = len(samples)
+        self.max_iterations = (self.n + self.batch_size - 1) // self.batch_size
+        self.iterations = self.max_iterations
+        self.seed_walk = 0
+        self.index_array = None
 
         # Initialize Standardization Subfunction
         if standardize_mode is not None:
@@ -259,10 +268,6 @@ class DataGenerator(Iterator):
             print("A directory for image preparation was created:",
                   self.prepare_dir)
 
-        # Pass initialization parameters to parent Iterator class
-        size = len(samples)
-        super(DataGenerator, self).__init__(size, batch_size, shuffle, seed)
-
     #-----------------------------------------------------#
     #              Batch Generation Function              #
     #-----------------------------------------------------#
@@ -310,17 +315,19 @@ class DataGenerator(Iterator):
     #-----------------------------------------------------#
     #                 Image Preprocessing                 #
     #-----------------------------------------------------#
-    """ Internal preprocessing function for applying Subfunctions, augmentation, resizing and standardization
-        on an image given its index.
-
-    Activating the prepared_image option also allows loading a beforehand preprocessed image from disk.
-
-    Deactivating the run_aug & run_standardize option to output image without augmentation and standardization.
-
-    Activating dump_pickle will store the preprocessed image as pickle on disk instead of returning.
-    """
     def preprocess_image(self, index, prepared_image=False, run_aug=True,
                          run_standardize=True, dump_pickle=False):
+        """ Internal preprocessing function for applying Subfunctions, augmentation, resizing and standardization
+            on an image given its index.
+
+        Can be utilized for debugging purposes.
+
+        Activating the prepared_image option also allows loading a beforehand preprocessed image from disk.
+
+        Deactivating the run_aug & run_standardize option to output image without augmentation and standardization.
+
+        Activating dump_pickle will store the preprocessed image as pickle on disk instead of returning.
+        """
         # Load prepared image from disk
         if prepared_image:
             # Load from disk
@@ -359,3 +366,53 @@ class DataGenerator(Iterator):
                 pickle.dump(img, pickle_writer)
         # Return preprocessed image
         else : return img
+
+    #-----------------------------------------------------#
+    #              Sample Generation Function             #
+    #-----------------------------------------------------#
+    """ Internal function for calling the batch generation process. """
+    def __getitem__(self, raw_idx):
+        # Obtain the index based on the passed index offset to allow repetition
+        idx = raw_idx % self.max_iterations
+        # Build index array for the start
+        if self.index_array is None:
+            self.__set_index_array__()
+        # Select samples for next batch
+        index_array = self.index_array[
+            self.batch_size * idx : self.batch_size * (idx + 1)
+        ]
+        # Generate batch
+        print(self.index_array, raw_idx, idx, index_array)
+        return self._get_batches_of_transformed_samples(index_array)
+
+    #-----------------------------------------------------#
+    #                 Generator Functions                 #
+    #-----------------------------------------------------#
+    """ Internal function for identifying the generator length. """
+    def __len__(self):
+        return self.iterations
+
+    """ Configuration function for fixing the number of iterations. """
+    def set_length(self, iterations):
+        self.iterations = iterations
+
+    """ Configuration function for reseting the number of iterations. """
+    def reset_length(self):
+        self.iterations = self.max_iterations
+
+    """ Internal function for initializing and shuffling the index array. """
+    def __set_index_array__(self):
+        # Generate index array
+        self.index_array = np.arange(self.n)
+        # Shuffle if needed
+        if self.shuffle:
+            # Update seed for repeated permutation of the index_array
+            if self.seed is not None:
+                np.random.seed(self.seed + self.seed_walk)
+                self.seed_walk += 1
+            # Permutate index array
+            self.index_array = np.random.permutation(self.n)
+
+    """ Internal function at the end of an epoch. """
+    def on_epoch_end(self):
+        self.__set_index_array__()

--- a/aucmedi/xai/methods/occlusion_sensitivity.py
+++ b/aucmedi/xai/methods/occlusion_sensitivity.py
@@ -42,7 +42,7 @@ class OcclusionSensitivity(XAImethod_Base):
     This class provides functionality for running the compute_heatmap function,
     which computes a Occlusion Sensitivity Map for an image with a model.
     """
-    def __init__(self, model, layerName=None, patch_size=4):
+    def __init__(self, model, layerName=None, patch_size=16):
         """ Initialization function for creating a Occlusion Sensitivity Map as XAI Method object.
 
         Args:

--- a/tests/test_datagenerator.py
+++ b/tests/test_datagenerator.py
@@ -104,7 +104,7 @@ class DataGeneratorTEST(unittest.TestCase):
         data_gen = DataGenerator(self.sampleList_gray_2D, self.tmp_data.name,
                                  grayscale=True, batch_size=5)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 1)
             self.assertTrue(np.array_equal(batch[0].shape, (5, 224, 224, 1)))
 
@@ -113,7 +113,7 @@ class DataGeneratorTEST(unittest.TestCase):
         data_gen = DataGenerator(self.sampleList_rgb_2D, self.tmp_data.name,
                                  grayscale=False, batch_size=5)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 1)
             self.assertTrue(np.array_equal(batch[0].shape, (5, 224, 224, 3)))
 
@@ -123,7 +123,7 @@ class DataGeneratorTEST(unittest.TestCase):
                                  labels=self.labels_ohe,
                                  grayscale=False, batch_size=5)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 2)
             self.assertTrue(np.array_equal(batch[1].shape, (5, 4)))
 
@@ -137,7 +137,7 @@ class DataGeneratorTEST(unittest.TestCase):
                                  loader=numpy_loader, resize=None,
                                  standardize_mode=None)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 1)
             self.assertTrue(np.array_equal(batch[0].shape, (5, 16, 16, 16, 1)))
 
@@ -148,7 +148,7 @@ class DataGeneratorTEST(unittest.TestCase):
                                  loader=numpy_loader, resize=None,
                                  standardize_mode=None)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 1)
             self.assertTrue(np.array_equal(batch[0].shape, (5, 16, 16, 16, 3)))
 
@@ -160,7 +160,7 @@ class DataGeneratorTEST(unittest.TestCase):
                                  loader=numpy_loader, resize=None,
                                  standardize_mode=None)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 2)
             self.assertTrue(np.array_equal(batch[1].shape, (5, 4)))
 
@@ -173,7 +173,7 @@ class DataGeneratorTEST(unittest.TestCase):
                                  metadata=self.metadata, grayscale=False,
                                  batch_size=5)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 1)
             self.assertTrue(len(batch[0]) == 2)
             self.assertTrue(np.array_equal(batch[0][0].shape, (5, 224, 224, 3)))
@@ -185,7 +185,7 @@ class DataGeneratorTEST(unittest.TestCase):
                              labels=self.labels_ohe, metadata=self.metadata,
                              grayscale=False, batch_size=5)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 2)
             self.assertTrue(np.array_equal(batch[1].shape, (5, 4)))
             self.assertTrue(len(batch[0]) == 2)
@@ -200,7 +200,7 @@ class DataGeneratorTEST(unittest.TestCase):
                                  labels=self.labels_ohe,
                                  grayscale=False, batch_size=5, workers=5)
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 2)
             self.assertTrue(np.array_equal(batch[1].shape, (5, 4)))
 
@@ -214,7 +214,7 @@ class DataGeneratorTEST(unittest.TestCase):
         precprocessed_images = os.listdir(data_gen.prepare_dir)
         self.assertTrue(len(precprocessed_images), len(self.sampleList_rgb_2D))
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 2)
             self.assertTrue(np.array_equal(batch[1].shape, (5, 4)))
         shutil.rmtree(data_gen.prepare_dir)
@@ -226,7 +226,23 @@ class DataGeneratorTEST(unittest.TestCase):
         precprocessed_images = os.listdir(data_gen.prepare_dir)
         self.assertTrue(len(precprocessed_images), len(self.sampleList_rgb_2D))
         for i in range(0, 10):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(len(batch), 2)
             self.assertTrue(np.array_equal(batch[1].shape, (5, 4)))
         shutil.rmtree(data_gen.prepare_dir)
+
+    #-------------------------------------------------#
+    #                   Utilization                   #
+    #-------------------------------------------------#
+    # Class Creation
+    def test_utils_iter(self):
+        data_gen = DataGenerator(self.sampleList_rgb_2D, self.tmp_data.name,
+                                 batch_size=8)
+        counter = 0
+        for batch in data_gen:
+            if counter < 3:
+                self.assertTrue(np.array_equal(batch[0].shape, (8,224,224,3)))
+            else: 
+                self.assertTrue(np.array_equal(batch[0].shape, (1,224,224,3)))
+            counter += 1
+        self.assertTrue(counter == 4)

--- a/tests/test_ioloader.py
+++ b/tests/test_ioloader.py
@@ -63,7 +63,7 @@ class IOloaderTEST(unittest.TestCase):
         data_gen = DataGenerator(sample_list, tmp_data.name, resize=None,
                                  grayscale=False, batch_size=2)
         for i in range(0, 3):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(np.array_equal(batch[0].shape, (2, 16, 16, 3)))
 
     # Test for grayscale images
@@ -119,7 +119,7 @@ class IOloaderTEST(unittest.TestCase):
                                  resize=None, two_dim=False, standardize_mode=None,
                                  grayscale=True, batch_size=2)
         for i in range(0, 3):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(np.array_equal(batch[0].shape, (2, 16, 16, 16, 1)))
 
     # Test for grayscale 2D images
@@ -214,7 +214,7 @@ class IOloaderTEST(unittest.TestCase):
                                  resize=None, standardize_mode=None,
                                  grayscale=True, batch_size=1)
         for i in range(0, 6):
-            batch = next(data_gen)
+            batch = data_gen[i]
             if i < 3:
                 self.assertTrue(np.array_equal(batch[0].shape, (1, 32, 24, 8, 1)))
             else:
@@ -278,7 +278,7 @@ class IOloaderTEST(unittest.TestCase):
                                  resize=None, standardize_mode=None,
                                  grayscale=True, batch_size=1)
         for i in range(0, 6):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(np.array_equal(batch[0].shape, (1, 18, 10, 10, 1)))
 
     #-------------------------------------------------#
@@ -301,7 +301,7 @@ class IOloaderTEST(unittest.TestCase):
                                  resize=None, two_dim=False, standardize_mode=None,
                                  grayscale=True, batch_size=2, cache=cache)
         for i in range(0, 3):
-            batch = next(data_gen)
+            batch = data_gen[i]
             self.assertTrue(np.array_equal(batch[0].shape, (2, 16, 16, 16, 1)))
 
     # Test for grayscale 2D images

--- a/tests/test_neuralnetwork.py
+++ b/tests/test_neuralnetwork.py
@@ -42,7 +42,7 @@ class NeuralNetworkTEST(unittest.TestCase):
 
         # Create RGB data
         self.sampleList_rgb = []
-        for i in range(0, 1):
+        for i in range(0, 10):
             img_rgb = np.random.rand(32, 32, 3) * 255
             imgRGB_pillow = Image.fromarray(img_rgb.astype(np.uint8))
             index = "image.sample_" + str(i) + ".RGB.png"
@@ -51,8 +51,8 @@ class NeuralNetworkTEST(unittest.TestCase):
             self.sampleList_rgb.append(index)
 
         # Create classification labels
-        self.labels_ohe = np.zeros((1, 4), dtype=np.uint8)
-        for i in range(0, 1):
+        self.labels_ohe = np.zeros((10, 4), dtype=np.uint8)
+        for i in range(0, 10):
             class_index = np.random.randint(0, 4)
             self.labels_ohe[i][class_index] = 1
 
@@ -61,7 +61,8 @@ class NeuralNetworkTEST(unittest.TestCase):
                                      self.tmp_data.name,
                                      labels=self.labels_ohe,
                                      resize=(32, 32),
-                                     grayscale=False, batch_size=1)
+                                     shuffle=True,
+                                     grayscale=False, batch_size=3)
 
     #-------------------------------------------------#
     #                  Model Training                 #
@@ -78,6 +79,11 @@ class NeuralNetworkTEST(unittest.TestCase):
                            epochs=5, iterations=10)
         self.assertTrue("loss" in hist)
         self.assertTrue(len(hist["loss"]) == 5)
+
+        hist = model.train(training_generator=self.datagen,
+                           epochs=3, iterations=2)
+        self.assertTrue("loss" in hist)
+        self.assertTrue(len(hist["loss"]) == 3)
 
     def test_training_validation(self):
         model = NeuralNetwork(n_labels=4, channels=3, batch_queue_size=1)
@@ -101,5 +107,6 @@ class NeuralNetworkTEST(unittest.TestCase):
     def test_predict(self):
         model = NeuralNetwork(n_labels=4, channels=3, batch_queue_size=1)
         preds = model.predict(self.datagen)
-        self.assertTrue(preds.shape == (1, 4))
-        self.assertTrue(np.sum(preds) >= 0.99 and np.sum(preds) <= 1.01)
+        self.assertTrue(preds.shape == (10, 4))
+        for i in range(0, 10):
+            self.assertTrue(np.sum(preds[i]) >= 0.99 and np.sum(preds[i]) <= 1.01)

--- a/tests/test_xai.py
+++ b/tests/test_xai.py
@@ -68,7 +68,7 @@ class xaiTEST(unittest.TestCase):
         # Compute predictions
         self.preds = self.model.predict(self.datagen)
         # Initialize testing image
-        self.image = next(self.datagen)[0][[0]]
+        self.image = self.datagen[0][0][[0]]
 
     #-------------------------------------------------#
     #             XAI Functions: Decoder              #


### PR DESCRIPTION
Continue using keras.Sequence as DataGenerator for generating batches instead of switching to tf.datasets due to massive performance leaks.