### PR TITLE
feat(dependency): Account for OS when selecting Tensorflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-tensorflow==2.11.1
+tensorflow==2.11.1;sys_platform!="darwin"
+tensorflow-macos==2.11.1;sys_platform=="darwin"
 tensorflow-addons==0.18.0
 keras-applications==1.0.8
 numpy==1.23.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ setup(
         'console_scripts': ['aucmedi = aucmedi.automl.main:main'],
     },
     python_requires='>=3.8',
-    install_requires=['tensorflow>=2.11.1',
+    install_requires=[
+                      'tensorflow>=2.11.1;sys_platform!="darwin"',
+                      'tensorflow>=2.11.1;sys_platform=="darwin"',
                       'tensorflow-addons>=0.18.0',
                       'keras-applications>=1.0.8',
                       'numpy>=1.23.0',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     python_requires='>=3.8',
     install_requires=[
                       'tensorflow>=2.11.1;sys_platform!="darwin"',
-                      'tensorflow>=2.11.1;sys_platform=="darwin"',
+                      'tensorflow-macos>=2.11.1;sys_platform=="darwin"',
                       'tensorflow-addons>=0.18.0',
                       'keras-applications>=1.0.8',
                       'numpy>=1.23.0',


### PR DESCRIPTION
Should close #206 

(due to limited hardware access this has not been tested.)