### PR TITLE
fix: classes parameter (change np.array)

### DIFF
--- a/aucmedi/utils/class_weights.py
+++ b/aucmedi/utils/class_weights.py
@@ -100,7 +100,7 @@ def compute_multilabel_weights(ohe_array, method="balanced"):
     class_weights = np.empty([n_classes])
     # Compute weight for each class individually
     for i in range(0, n_classes):
-        weight = compute_class_weight(class_weight=method, classes=[0,1],
+        weight = compute_class_weight(class_weight=method, classes=np.array([0,1]),
                                       y=ohe_array[:, i])
         class_weights[i] = weight[1]
     # Return resulting class weight list


### PR DESCRIPTION
# Environment
- AUCMEDI 0.8.1
- Ubuntu 18.04
- tensorflow 2.15.0
- CUDA 12.2
- cuDNN 8.9
- Python 2.15.0

# Traceback
```
Traceback (most recent call last):
  File "~/.../script.py", line 154, in <module>
    weights = compute_multilabel_weights(ohe_array=y_train)
  File "~/anaconda3/envs/ailab/lib/python3.10/site-packages/aucmedi/utils/class_weights.py", line 103, in compute_multilabel_weights
    weight = compute_class_weight(class_weight=method, classes=[0,1],
  File "~/anaconda3/envs/ailab/lib/python3.10/site-packages/sklearn/utils/_param_validation.py", line 203, in wrapper
    validate_parameter_constraints(
  File "~/anaconda3/envs/ailab/lib/python3.10/site-packages/sklearn/utils/_param_validation.py", line 95, in validate_parameter_constraints
    raise InvalidParameterError(
sklearn.utils._param_validation.InvalidParameterError: The 'classes' parameter of compute_class_weight must be an instance of 'numpy.ndarray'. Got [0, 1] instead.
```

# Fix
- change `[0, 1]` to `np.array([0, 1])`