### PR TITLE
Fix(F1Score): correct computation of F1Score in automl training

### DIFF
--- a/aucmedi/automl/block_train.py
+++ b/aucmedi/automl/block_train.py
@@ -23,7 +23,7 @@
 import os
 import numpy as np
 import json
-from tensorflow.keras.metrics import AUC
+from tensorflow.keras.metrics import AUC, F1Score
 from tensorflow.keras.callbacks import ModelCheckpoint, CSVLogger, \
                                        ReduceLROnPlateau, EarlyStopping
 # Internal libraries
@@ -139,7 +139,7 @@ def block_train(config):
                 "workers": config["workers"],
                 "batch_queue_size": 4,
                 "loss": loss,
-                "metrics": [AUC(100)],
+                "metrics": [AUC(100), F1Score(average="macro")],
                 "pretrained_weights": True,
                 "multiprocessing": False,
     }

--- a/aucmedi/data_processing/data_generator.py
+++ b/aucmedi/data_processing/data_generator.py
@@ -293,7 +293,7 @@ class DataGenerator(Sequence):
 
         # Add classification to batch if available
         if self.labels is not None:
-            batch_stack[1].extend(self.labels[index_array])
+            batch_stack[1].extend(np.float32(self.labels[index_array]))
         # Add sample weight to batch if available
         if self.sample_weights is not None:
             batch_stack[2].extend(self.sample_weights[index_array])


### PR DESCRIPTION
This pull request addresses issue #224.

Changes made: 
* Added F1Score compution to automl training block. 
* Added labels cast to prevent type errors. 

Files modified: 
* `aucmedi/automl/block_train.py`
* `aucmedi/data_processing/data_generator.py`

Please review the changes and let me know if there are any questions or further adjustments needed.