### PR TITLE
Add reproducible k-fold splitting and CSV export to Bagging

### DIFF
--- a/aucmedi/ensemble/bagging.py
+++ b/aucmedi/ensemble/bagging.py
@@ -97,7 +97,7 @@ class Bagging:
         An Analysis on Ensemble Learning optimized Medical Image Classification with Deep Convolutional Neural Networks.
         arXiv e-print: [https://arxiv.org/abs/2201.11440](https://arxiv.org/abs/2201.11440)
     """
-    def __init__(self, model, k_fold=3):
+    def __init__(self, model, k_fold=3, seed=None):
         """ Initialization function for creating a Bagging object.
 
         Args:
@@ -108,6 +108,7 @@ class Bagging:
         self.model_template = model
         self.k_fold = k_fold
         self.cache_dir = None
+        self.seed = seed
 
         # Set multiprocessing method to spawn
         mp.set_start_method("spawn", force=True)
@@ -149,7 +150,7 @@ class Bagging:
 
         # Apply cross-validaton sampling
         cv_sampling = sampling_kfold(x, y, m, n_splits=self.k_fold,
-                                     stratified=True, iterative=True)
+                                     stratified=True, iterative=True, seed=self.seed)
 
         # Sequentially iterate over all folds
         for i, fold in enumerate(cv_sampling):

--- a/aucmedi/ensemble/bagging.py
+++ b/aucmedi/ensemble/bagging.py
@@ -26,6 +26,7 @@ from tensorflow.keras.callbacks import ModelCheckpoint, CSVLogger
 from pathos.helpers import mp   # instead of 'import multiprocessing as mp'
 import numpy as np
 import shutil
+import pandas as pd
 # Internal libraries
 from aucmedi import DataGenerator, NeuralNetwork
 from aucmedi.sampling import sampling_kfold
@@ -151,6 +152,38 @@ class Bagging:
         # Apply cross-validaton sampling
         cv_sampling = sampling_kfold(x, y, m, n_splits=self.k_fold,
                                      stratified=True, iterative=True, seed=self.seed)
+        
+        # Save cross-validation sampling in list
+        records = []
+
+        # Sequentially iterate over all folds
+        for i, fold in enumerate(cv_sampling):
+            if len(fold) == 4:
+                train_x, train_y, val_x, val_y = fold
+            else:
+                train_x, train_y, _, val_x, val_y, _ = fold
+
+            # Training data
+            for sample, label in zip(train_x, train_y):
+                records.append({
+                    'fold': i,
+                    'subset': 'train',
+                    'sample': sample,
+                    'label': int(np.argmax(label))
+                })
+
+            # Validation data
+            for sample, label in zip(val_x, val_y):
+                records.append({
+                    'fold': i,
+                    'subset': 'val',
+                    'sample': sample,
+                    'label': int(np.argmax(label))
+                })
+
+        # Save as CSV
+        df = pd.DataFrame(records)
+        df.to_csv(os.path.join(self.cache_dir.name, "kfold_split.csv"), index=False)
 
         # Sequentially iterate over all folds
         for i, fold in enumerate(cv_sampling):

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -214,19 +214,19 @@ class EnsembleTEST(unittest.TestCase):
         target = tempfile.TemporaryDirectory(prefix="tmp.aucmedi.",
                                              suffix=".model")
         self.assertTrue(len(os.listdir(target.name))==0)
-        self.assertTrue(len(os.listdir(el.cache_dir.name))==4)
+        self.assertTrue(len(os.listdir(el.cache_dir.name))==5)
         origin = el.cache_dir.name
         # Dump model
         target_dir = os.path.join(target.name, "test")
         el.dump(target_dir)
-        self.assertTrue(len(os.listdir(target_dir))==4)
+        self.assertTrue(len(os.listdir(target_dir))==5)
         self.assertFalse(os.path.exists(origin))
         target_two = tempfile.TemporaryDirectory(prefix="tmp.aucmedi.",
                                                  suffix=".model")
         target_dir_two = os.path.join(target_two.name, "test")
         el.dump(target_dir_two)
-        self.assertTrue(len(os.listdir(target_dir_two))==4)
-        self.assertTrue(len(os.listdir(target_dir))==4)
+        self.assertTrue(len(os.listdir(target_dir_two))==5)
+        self.assertTrue(len(os.listdir(target_dir))==5)
         self.assertTrue(os.path.exists(target_dir))
 
     def test_Bagging_load(self):


### PR DESCRIPTION
This pull request introduces two related features to improve the reproducibility of k-fold cross-validation in the Bagging class:

1. **Seed parameter**  
   - Adds a `seed` class attribute to allow deterministic behavior in `sampling_kfold`.

2. **CSV export of splits**  
   - Saves the generated train/val splits for each fold to a CSV file (`kfold_split.csv`).
   - Includes fold number, subset type (train/val), sample name, and the class label.

Let me know if anything should be adjusted.